### PR TITLE
Reverting NAT Gateway Removal

### DIFF
--- a/nat_gateway.tf
+++ b/nat_gateway.tf
@@ -1,0 +1,27 @@
+resource "azurerm_public_ip" "nat_gw_ip" {
+  name                = var.nat_gateway_ip_name
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+
+  tags = var.tags
+}
+
+resource "azurerm_nat_gateway" "lb_nat_gw" {
+  name                = var.nat_gateway_name
+  location            = var.location
+  resource_group_name = var.resource_group_name
+
+  tags = var.tags
+}
+
+resource "azurerm_subnet_nat_gateway_association" "nat_gw_association" {
+  subnet_id      = azurerm_subnet.subnet.id
+  nat_gateway_id = azurerm_nat_gateway.lb_nat_gw.id
+}
+
+resource "azurerm_nat_gateway_public_ip_association" "public_ip_association" {
+  nat_gateway_id       = azurerm_nat_gateway.lb_nat_gw.id
+  public_ip_address_id = azurerm_public_ip.nat_gw_ip.id
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,6 +2,14 @@ output "internal_load_balancer_name" {
   value = azurerm_lb.scale_set_lb.name
 }
 
+output "nat_gateway_public_ip_name" {
+  value = azurerm_public_ip.nat_gw_ip.name
+}
+
+output "nat_gateway_name" {
+  value = azurerm_nat_gateway.lb_nat_gw.name
+}
+
 output "sensor_identity_principal_id" {
   value = azurerm_linux_virtual_machine_scale_set.sensor_scale_set.identity[0].principal_id
 }

--- a/variables.tf
+++ b/variables.tf
@@ -57,6 +57,18 @@ variable "sensor_admin_username" {
   default     = "corelight"
 }
 
+variable "nat_gateway_ip_name" {
+  description = "The resource name of the VMSS NAT Gateway public IP resource"
+  type        = string
+  default     = "cl-nat-gw-ip"
+}
+
+variable "nat_gateway_name" {
+  description = "The resource name of the VMSS NAT Gateway resource"
+  type        = string
+  default     = "cl-sensor-nat-gw"
+}
+
 variable "autoscale_setting_name" {
   description = "The VMSS autoscale monitor name"
   type        = string


### PR DESCRIPTION
# Description

Adding the NAT gateway back just incase people want to use a public endpoint for exporters. Didn't think about that when I removed it. Whoops.

## Type of change

Please delete options that are not relevant.

- [X] Bug Fix
- [ ] New Feature
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested locally successfully 