### PR TITLE
support fleet configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ module "sensor" {
     purpose: Corelight
   }
 
+  # Optional - Fleet Manager
+  fleet_token = "<the pairing token from the Fleet UI>"
+  fleet_url   = "<the URL of the fleet instance from the Fleet UI>"
+
   # (Optional) Cloud Enrichment Variables
   enrichment_storage_account_name   = "<name of the enrichment storage account>"
   enrichment_storage_container_name = "<name of the enrichment container in the storage account>"

--- a/examples/deployment/main.tf
+++ b/examples/deployment/main.tf
@@ -7,6 +7,8 @@ locals {
     terraform : true,
     purpose : "Corelight"
   }
+  fleet_token = "b1cd099ff22ed8a41abc63929d1db126"
+  fleet_url   = "https://fleet.example.com:1443/fleet/v1/internal/softsensor/websocket"
 }
 
 ####################################################################################################
@@ -41,6 +43,8 @@ module "sensor" {
   virtual_network_address_space  = "<vnet address space (CIDR)>"
   corelight_sensor_image_id      = "<image resource id from Corelight>"
   community_string               = "<the community string (api string) often times referenced by Fleet>"
+  fleet_token                    = local.fleet_token
+  fleet_url                      = local.fleet_url
   sensor_ssh_public_key          = "<path to ssh public key>"
 
   # (Optional) Cloud Enrichment Variables

--- a/sensor_config.tf
+++ b/sensor_config.tf
@@ -7,6 +7,12 @@ module "sensor_config" {
   source = "github.com/corelight/terraform-config-sensor?ref=v0.1.0"
 
   fleet_community_string                       = var.community_string
+  fleet_token                                  = var.fleet_token
+  fleet_url                                    = var.fleet_url
+  fleet_server_sslname                         = var.fleet_server_sslname
+  fleet_http_proxy                             = var.fleet_http_proxy
+  fleet_https_proxy                            = var.fleet_https_proxy
+  fleet_no_proxy                               = var.fleet_no_proxy
   sensor_license                               = var.license_key
   sensor_management_interface_name             = "eth0"
   sensor_monitoring_interface_name             = "eth1"

--- a/variables.tf
+++ b/variables.tf
@@ -164,3 +164,41 @@ variable "tags" {
   type        = object({})
   default     = {}
 }
+
+variable "fleet_token" {
+  type        = string
+  default     = ""
+  sensitive   = true
+  description = "(optional) the pairing token from the Fleet UI. Must be set if 'fleet_url' is provided"
+}
+
+variable "fleet_url" {
+  type        = string
+  default     = ""
+  description = "(optional) the URL of the fleet instance from the Fleet UI. Must be set if 'fleet_token' is provided"
+}
+
+variable "fleet_server_sslname" {
+  type        = string
+  default     = "1.broala.fleet.product.corelight.io"
+  description = "(optional) the SSL hostname for the fleet server"
+
+}
+
+variable "fleet_http_proxy" {
+  type        = string
+  default     = ""
+  description = "(optional) the proxy URL for HTTP traffic from the fleet"
+}
+
+variable "fleet_https_proxy" {
+  type        = string
+  default     = ""
+  description = "(optional) the proxy URL for HTTPS traffic from the fleet"
+}
+
+variable "fleet_no_proxy" {
+  type        = string
+  default     = ""
+  description = "(optional) hosts or domains to bypass the proxy for fleet traffic"
+}


### PR DESCRIPTION
# Description

Ability to pair the sensor to Fleet.

Fixes #CLOUD-270, but depends on https://github.com/corelight/terraform-config-sensor/pull/10

## Type of change

Please delete options that are not relevant.

- [ ] Bug Fix
- [x] New Feature
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested locally