### PR TITLE
November 2024 Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,12 @@ module "sensor" {
   license_key                    = "<your Corelight sensor license key>"
   location                       = "<Azure location to deploy resources in>"
   resource_group_name            = "<resource group to deploy in>"
-  virtual_network_name           = "<virtual network where VMSS subnet should be deployed>"
-  virtual_network_resource_group = "<virtual network resource group>"
-  virtual_network_address_space  = "<virtual network address space (CIDR) used to create subnet>"
   corelight_sensor_image_id      = "<image resource id from Corelight>"
   community_string               = "<the community string (api string) often times referenced by Fleet>"
   sensor_ssh_public_key          = "<path to ssh public key>"
-
+  management_subnet_id           = "<full management NIC subnet resource ID>"
+  monitoring_subnet_id           = "<full management NIC subnet resource ID>"
+    
   tags = {
     foo: bar,
     terraform: true,

--- a/load_balancer.tf
+++ b/load_balancer.tf
@@ -6,7 +6,7 @@ resource "azurerm_lb" "scale_set_lb" {
 
   frontend_ip_configuration {
     name      = var.lb_frontend_ip_config_name
-    subnet_id = azurerm_subnet.subnet.id
+    subnet_id = var.monitoring_subnet_id
   }
 
   tags = var.tags
@@ -25,11 +25,12 @@ resource "azurerm_lb_backend_address_pool" "monitoring_pool" {
 resource "azurerm_lb_probe" "sensor_health_check_probe" {
   loadbalancer_id     = azurerm_lb.scale_set_lb.id
   name                = var.lb_health_check_probe_name
-  port                = 443
-  request_path        = "/api/system/healthcheck/"
-  protocol            = "Https"
+  port                = 41080
+  request_path        = "/api/system/healthcheck"
+  protocol            = "Http"
   interval_in_seconds = 30
-  probe_threshold     = 3
+  number_of_probes    = 2
+  probe_threshold     = 2
 }
 
 resource "azurerm_lb_rule" "monitoring_vxlan_lb_rule" {
@@ -45,28 +46,15 @@ resource "azurerm_lb_rule" "monitoring_vxlan_lb_rule" {
   probe_id = azurerm_lb_probe.sensor_health_check_probe.id
 }
 
-resource "azurerm_lb_rule" "monitoring_geneve_lb_rule" {
-  name                           = var.lb_geneve_rule_name
-  loadbalancer_id                = azurerm_lb.scale_set_lb.id
-  protocol                       = "Udp"
-  backend_port                   = 6081
-  frontend_port                  = 6081
-  frontend_ip_configuration_name = azurerm_lb.scale_set_lb.frontend_ip_configuration[0].name
-  backend_address_pool_ids = [
-    azurerm_lb_backend_address_pool.monitoring_pool.id
-  ]
-  probe_id = azurerm_lb_probe.sensor_health_check_probe.id
-}
-
 resource "azurerm_lb_rule" "monitoring_health_check_rule" {
   name                           = var.lb_health_check_rule_name
   loadbalancer_id                = azurerm_lb.scale_set_lb.id
   protocol                       = "Tcp"
-  backend_port                   = 443
-  frontend_port                  = 443
+  backend_port                   = 41080
+  frontend_port                  = 41080
   frontend_ip_configuration_name = azurerm_lb.scale_set_lb.frontend_ip_configuration[0].name
   backend_address_pool_ids = [
-    azurerm_lb_backend_address_pool.management_pool.id
+    azurerm_lb_backend_address_pool.monitoring_pool.id
   ]
   probe_id = azurerm_lb_probe.sensor_health_check_probe.id
 }

--- a/nat_gateway.tf
+++ b/nat_gateway.tf
@@ -17,7 +17,7 @@ resource "azurerm_nat_gateway" "lb_nat_gw" {
 }
 
 resource "azurerm_subnet_nat_gateway_association" "nat_gw_association" {
-  subnet_id      = azurerm_subnet.subnet.id
+  subnet_id      = var.management_subnet_id
   nat_gateway_id = azurerm_nat_gateway.lb_nat_gw.id
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -18,6 +18,6 @@ output "sensor_scale_set_name" {
   value = azurerm_linux_virtual_machine_scale_set.sensor_scale_set.name
 }
 
-output "sensor_scale_set_subnet_name" {
-  value = azurerm_subnet.subnet.name
+output "sensor_load_balancer_frontend_ip_address" {
+  value = azurerm_lb.scale_set_lb.frontend_ip_configuration[0].private_ip_address
 }

--- a/sensor_config.tf
+++ b/sensor_config.tf
@@ -17,7 +17,6 @@ module "sensor_config" {
   sensor_management_interface_name             = "eth0"
   sensor_monitoring_interface_name             = "eth1"
   sensor_health_check_probe_source_ranges_cidr = [local.azure_lb_health_check_probe_ip]
-  sensor_health_check_http_port                = 443
   gzip_config                                  = true
   base64_encode_config                         = true
   enrichment_enabled                           = var.enrichment_storage_account_name != "" && var.enrichment_storage_container_name != ""

--- a/subnet.tf
+++ b/subnet.tf
@@ -1,8 +1,0 @@
-resource "azurerm_subnet" "subnet" {
-  name                 = var.sensor_subnet_name
-  virtual_network_name = var.virtual_network_name
-  resource_group_name  = var.virtual_network_resource_group
-  address_prefixes = [
-    cidrsubnet(var.virtual_network_address_space, 8, 1)
-  ]
-}

--- a/variables.tf
+++ b/variables.tf
@@ -14,18 +14,13 @@ variable "license_key" {
   sensitive   = true
 }
 
-variable "virtual_network_name" {
-  description = "The name of the virtual network the sensor will be deployed in"
+variable "management_subnet_id" {
+  description = "The subnet used to access the sensor"
   type        = string
 }
 
-variable "virtual_network_address_space" {
-  description = "The address space of the virtual network the sensor be deployed in"
-  type        = string
-}
-
-variable "virtual_network_resource_group" {
-  description = "The resource group where the virtual network is deployed"
+variable "monitoring_subnet_id" {
+  description = "The subnet used for monitoring traffic"
   type        = string
 }
 
@@ -54,7 +49,7 @@ variable "sensor_subnet_name" {
 variable "sensor_admin_username" {
   description = "The name of the admin user on the corelight sensor VM in the VMSS"
   type        = string
-  default     = "corelight"
+  default     = "ubuntu"
 }
 
 variable "nat_gateway_ip_name" {
@@ -201,4 +196,10 @@ variable "fleet_no_proxy" {
   type        = string
   default     = ""
   description = "(optional) hosts or domains to bypass the proxy for fleet traffic"
+}
+
+variable "monitoring_nsg_name" {
+  type        = string
+  default     = "corelight-monitoring-nsg"
+  description = "(optional) Name of the monitoring network security group"
 }


### PR DESCRIPTION
# Description

- Removed VMSS subnet creation. The monitoring and management subnets will need to be provisioned prior.  
- Renamed the sensor admin user to "ubuntu" to match our documentation
- Updated and fixed the health check to use the appropriate 41080 port on the monitoring NIC
- Added the Linux Health Extension to provide a grace period before health checks are sent to allow the sensor to come up
- Enabled accelerated networking for the monitoring NIC on the sensor

## Type of change

Please delete options that are not relevant.

- [X] Bug Fix
- [X] New Feature
- [X] This change requires a documentation update

# How Has This Been Tested?

Tested several times in Corelight subscription successfully