### PR TITLE
VM extension port can't be a string and must be a number

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -1,9 +1,9 @@
 locals {
   monitoring_subnet_resource_id_slice = split("/", var.monitoring_subnet_id)
-  monitoring_subnet_name              = local.monitoring_subnet_resource_id_slice[length(local.monitoring_subnet_resource_id_slice) - 1]
-  monitoring_subnet_vnet_name         = local.monitoring_subnet_resource_id_slice[8]
+  monitoring_subnet_name      = local.monitoring_subnet_resource_id_slice[length(local.monitoring_subnet_resource_id_slice) - 1]
+  monitoring_subnet_vnet_name = local.monitoring_subnet_resource_id_slice[8]
 
-  monitoring_health_check_port = "41080"
+  monitoring_health_check_port = 41080
 
   # https://learn.microsoft.com/en-us/azure/load-balancer/load-balancer-custom-probe-overview#probe-source-ip-address
   azure_lb_health_check_probe_ip = "168.63.129.16/32"

--- a/locals.tf
+++ b/locals.tf
@@ -1,7 +1,7 @@
 locals {
   monitoring_subnet_resource_id_slice = split("/", var.monitoring_subnet_id)
-  monitoring_subnet_name      = local.monitoring_subnet_resource_id_slice[length(local.monitoring_subnet_resource_id_slice) - 1]
-  monitoring_subnet_vnet_name = local.monitoring_subnet_resource_id_slice[8]
+  monitoring_subnet_name              = local.monitoring_subnet_resource_id_slice[length(local.monitoring_subnet_resource_id_slice) - 1]
+  monitoring_subnet_vnet_name         = local.monitoring_subnet_resource_id_slice[8]
 
   monitoring_health_check_port = 41080
 


### PR DESCRIPTION
# Description

The VM Extension is failing on deployments due to the port value being a string. This wasn't discovered during testing of the last change. Correcting here.

## Type of change

Please delete options that are not relevant.

- [X] Bug Fix
- [ ] New Feature
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested in my subscription with a successful deployment.
