### PR TITLE
Fixing Data bug and updating README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,20 @@ Deployment examples can be found [here][].
 
 [here]: https://github.com/corelight/corelight-cloud/tree/main/terraform/azure-scaleset-sensor
 
+#### Least Privilege Deployment
+The Corelight Azure sensor can be deployed with the following privileges:
+
+1. The `Network Contributor` built-in role
+2. `Microsoft.Compute/images/read` on the Corelight VM Image
+3. A custom role definition with the following permissions:
+```
+"Microsoft.Resources/subscriptions/resourcegroups/read"
+"Microsoft.Compute/virtualMachineScaleSets/read"
+"Microsoft.Insights/autoScaleSettings/read"
+"Microsoft.Compute/virtualMachineScaleSets/write"
+"Microsoft.Insights/autoScaleSettings/write"
+```
+
 ## License
 
 The project is licensed under the [MIT][] license.

--- a/data.tf
+++ b/data.tf
@@ -1,5 +1,5 @@
 data "azurerm_subnet" "mon_subnet" {
   name                 = local.monitoring_subnet_name
-  resource_group_name  = var.resource_group_name
+  resource_group_name  = local.monitoring_subnet_resource_group_name
   virtual_network_name = local.monitoring_subnet_vnet_name
 }

--- a/locals.tf
+++ b/locals.tf
@@ -1,9 +1,9 @@
 locals {
-  monitoring_subnet_resource_id_slice = split("/", var.monitoring_subnet_id)
-  monitoring_subnet_name              = local.monitoring_subnet_resource_id_slice[length(local.monitoring_subnet_resource_id_slice) - 1]
-  monitoring_subnet_vnet_name         = local.monitoring_subnet_resource_id_slice[8]
-
-  monitoring_health_check_port = 41080
+  monitoring_subnet_resource_id_slice   = split("/", var.monitoring_subnet_id)
+  monitoring_subnet_name                = local.monitoring_subnet_resource_id_slice[length(local.monitoring_subnet_resource_id_slice) - 1]
+  monitoring_subnet_resource_group_name = local.monitoring_subnet_resource_id_slice[4]
+  monitoring_subnet_vnet_name           = local.monitoring_subnet_resource_id_slice[8]
+  monitoring_health_check_port          = 41080
 
   # https://learn.microsoft.com/en-us/azure/load-balancer/load-balancer-custom-probe-overview#probe-source-ip-address
   azure_lb_health_check_probe_ip = "168.63.129.16/32"

--- a/sensor_config.tf
+++ b/sensor_config.tf
@@ -13,7 +13,7 @@ module "sensor_config" {
   sensor_monitoring_interface_name             = "eth1"
   sensor_health_check_probe_source_ranges_cidr = [local.azure_lb_health_check_probe_ip]
   sensor_health_check_http_port                = local.monitoring_health_check_port
-  subnetwork_monitoring_gateway                = cidrhost(data.azurerm_subnet.mon_subnet.address_prefix, 1)
+  subnetwork_monitoring_gateway                = cidrhost(data.azurerm_subnet.mon_subnet.address_prefixes[0], 1)
   subnetwork_monitoring_cidr                   = data.azurerm_subnet.mon_subnet.address_prefix
   gzip_config                                  = true
   base64_encode_config                         = true


### PR DESCRIPTION
# Description

Fixing a bug in `data.tf` where the resource group provided in the variables was assumed to be the same as the monitoring subnet which will likely not be true. Also added the least-privilege deployment permissions for the module.  

## Type of change

Please delete options that are not relevant.

- [X] Bug Fix
- [ ] New Feature
- [X] This change requires a documentation update

# How Has This Been Tested?

Tested in the Corelight Azure tenant with no issues
