### PR TITLE
add an output for the monitoring LB frontend IP configuration

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -18,6 +18,10 @@ output "sensor_scale_set_name" {
   value = azurerm_linux_virtual_machine_scale_set.sensor_scale_set.name
 }
 
-output "sensor_load_balancer_frontend_ip_address" {
+output "sensor_load_balancer_management_frontend_ip_address" {
   value = azurerm_lb.scale_set_lb.frontend_ip_configuration[0].private_ip_address
+}
+
+output "sensor_load_balancer_monitoring_frontend_ip_address" {
+  value = azurerm_lb.scale_set_lb.frontend_ip_configuration[1].private_ip_address
 }

--- a/scale_set.tf
+++ b/scale_set.tf
@@ -134,3 +134,4 @@ resource "azurerm_monitor_autoscale_setting" "auto_scale_config" {
     azurerm_lb_probe.sensor_health_check_probe
   ]
 }
+


### PR DESCRIPTION
# Description

To direct traffic to the sensor, we are interested in the _monitoring_ frontend IP configuration for the load balancer. This change adds an output to the module to expose it.

## Type of change

Please delete options that are not relevant.

- [x] Bug Fix
- [ ] New Feature
- [ ] This change requires a documentation update

# How Has This Been Tested?

Deployed the module as a destination from a packet broker.