### PR TITLE
tags issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ module "sensor" {
   fleet_server_sslname = "<the ssl name provided by Fleet>"
   
   tags = {
-    foo: bar,
-    terraform: true,
-    purpose: Corelight
+    foo       = "bar"
+    terraform = true
+    purpose   = "Corelight"
   }
 }
 ```

--- a/variables.tf
+++ b/variables.tf
@@ -161,7 +161,7 @@ variable "lb_ssh_rule_name" {
 
 variable "tags" {
   description = "Any tags that should be applied to resources deployed by the module"
-  type        = object({})
+  type        = map(string)
   default     = {}
 }
 


### PR DESCRIPTION
# Description
Tags are not applying correctly. Updated readme which is wrong as well as variable which requires a string map instead of an object.

## Type of change

Please delete options that are not relevant.

- [x ] Bug Fix


# How Has This Been Tested?

Tested with lab deployment. Confirmed tag format in readme example now works as well as confirmed tags are now applied to azure resources.
