### PR TITLE
Bug fixes and enhancements to health check config and nat gateway creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ module "sensor" {
   fleet_server_sslname = "<the ssl name provided by Fleet>"
   
   tags = {
-    foo: bar,
-    terraform: true,
-    purpose: Corelight
+    foo       = "bar"
+    terraform = true
+    purpose   = "Corelight"
   }
 }
 ```

--- a/load_balancer.tf
+++ b/load_balancer.tf
@@ -51,7 +51,7 @@ resource "azurerm_lb_probe" "sensor_health_check_probe" {
   loadbalancer_id     = azurerm_lb.scale_set_lb.id
   name                = var.lb_monitoring_probe_name
   port                = local.monitoring_health_check_port
-  request_path        = "/api/system/healthcheck"
+  request_path        = "/api/system/healthcheck?services=core"
   protocol            = "Http"
   interval_in_seconds = 15
   number_of_probes    = 3

--- a/load_balancer.tf
+++ b/load_balancer.tf
@@ -51,7 +51,7 @@ resource "azurerm_lb_probe" "sensor_health_check_probe" {
   loadbalancer_id     = azurerm_lb.scale_set_lb.id
   name                = var.lb_monitoring_probe_name
   port                = local.monitoring_health_check_port
-  request_path        = "/api/system/healthcheck?services=core"
+  request_path        = var.healthcheck_path
   protocol            = "Http"
   interval_in_seconds = 15
   number_of_probes    = 3

--- a/nat_gateway.tf
+++ b/nat_gateway.tf
@@ -1,4 +1,6 @@
 resource "azurerm_public_ip" "nat_gw_ip" {
+  count = var.create_nat_gateway ? 1 : 0
+
   name                = var.nat_gateway_ip_name
   location            = var.location
   resource_group_name = var.resource_group_name
@@ -9,6 +11,8 @@ resource "azurerm_public_ip" "nat_gw_ip" {
 }
 
 resource "azurerm_nat_gateway" "lb_nat_gw" {
+  count = var.create_nat_gateway ? 1 : 0
+
   name                = var.nat_gateway_name
   location            = var.location
   resource_group_name = var.resource_group_name
@@ -17,11 +21,15 @@ resource "azurerm_nat_gateway" "lb_nat_gw" {
 }
 
 resource "azurerm_subnet_nat_gateway_association" "nat_gw_association" {
+  count = var.create_nat_gateway ? 1 : 0
+
   subnet_id      = var.management_subnet_id
-  nat_gateway_id = azurerm_nat_gateway.lb_nat_gw.id
+  nat_gateway_id = azurerm_nat_gateway.lb_nat_gw[0].id
 }
 
 resource "azurerm_nat_gateway_public_ip_association" "public_ip_association" {
-  nat_gateway_id       = azurerm_nat_gateway.lb_nat_gw.id
-  public_ip_address_id = azurerm_public_ip.nat_gw_ip.id
+  count = var.create_nat_gateway ? 1 : 0
+
+  nat_gateway_id       = azurerm_nat_gateway.lb_nat_gw[0].id
+  public_ip_address_id = azurerm_public_ip.nat_gw_ip[0].id
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,11 +3,11 @@ output "internal_load_balancer_name" {
 }
 
 output "nat_gateway_public_ip_name" {
-  value = azurerm_public_ip.nat_gw_ip.name
+  value = length(azurerm_public_ip.nat_gw_ip) > 0 ? azurerm_public_ip.nat_gw_ip[0].name : null
 }
 
 output "nat_gateway_name" {
-  value = azurerm_nat_gateway.lb_nat_gw.name
+  value = length(azurerm_nat_gateway.lb_nat_gw) > 0 ? azurerm_nat_gateway.lb_nat_gw[0].name : null
 }
 
 output "sensor_identity_principal_id" {

--- a/scale_set.tf
+++ b/scale_set.tf
@@ -59,7 +59,7 @@ resource "azurerm_linux_virtual_machine_scale_set" "sensor_scale_set" {
     type_handler_version       = "2.0"
     auto_upgrade_minor_version = true
     settings = jsonencode({
-      protocol          = "https"
+      protocol          = "http"
       port              = local.monitoring_health_check_port
       requestPath       = "/api/system/healthcheck"
       intervalInSeconds = 15
@@ -69,6 +69,11 @@ resource "azurerm_linux_virtual_machine_scale_set" "sensor_scale_set" {
   }
 
   tags = var.tags
+
+  depends_on = [
+    azurerm_lb_rule.management_lb_rule,
+    azurerm_lb_rule.monitoring_vxlan_lb_rule
+  ]
 }
 
 resource "azurerm_monitor_autoscale_setting" "auto_scale_config" {

--- a/scale_set.tf
+++ b/scale_set.tf
@@ -61,7 +61,7 @@ resource "azurerm_linux_virtual_machine_scale_set" "sensor_scale_set" {
     settings = jsonencode({
       protocol          = "http"
       port              = local.monitoring_health_check_port
-      requestPath       = "/api/system/healthcheck?services=core"
+      requestPath       = var.healthcheck_path
       intervalInSeconds = 15
       numberOfProbes    = 2
       gracePeriod       = 600

--- a/scale_set.tf
+++ b/scale_set.tf
@@ -61,7 +61,7 @@ resource "azurerm_linux_virtual_machine_scale_set" "sensor_scale_set" {
     settings = jsonencode({
       protocol          = "http"
       port              = local.monitoring_health_check_port
-      requestPath       = "/api/system/healthcheck"
+      requestPath       = "/api/system/healthcheck?services=core"
       intervalInSeconds = 15
       numberOfProbes    = 2
       gracePeriod       = 600

--- a/variables.tf
+++ b/variables.tf
@@ -200,3 +200,9 @@ variable "fedramp_mode_enabled" {
   default     = false
   description = "(optional) enable Fedramp mode"
 }
+
+variable "healthcheck_path" {
+  type        = string
+  default     = "/api/system/healthcheck"
+  description = "(optional) path for the health check probe"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,9 @@
+variable "create_nat_gateway" {
+  description = "Controls if the NAT gateway and its associated resources should be created."
+  type        = bool
+  default     = true
+}
+
 variable "location" {
   description = "The Azure location where resources will be deployed"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -161,7 +161,7 @@ variable "lb_ssh_rule_name" {
 
 variable "tags" {
   description = "Any tags that should be applied to resources deployed by the module"
-  type        = object({})
+  type        = map(string)
   default     = {}
 }
 


### PR DESCRIPTION
# Description
This change:

- fixes an issue with the vmss health check using https instead of http
- makes the health check path a variable so you can use the new core services health check parameter if desired but defaults to the old/full health check path so it will not change any existing deployments
- makes the nat gateway deployment options via a new variable because we have had to mostly deploy into existing subnets that already have nat gateways which makes using the module impossible. The default remains to create the NAT gateway so the update will not break any existing deployments.

## Type of change

Please delete options that are not relevant.

- [x ] Bug Fix
- [x] New Feature

# How Has This Been Tested?

This has been deployed with and without the NAT gateway and it has been confirmed to work with the new health check variable defined with the core services param or undefined to use the full health check.
